### PR TITLE
Implement setting to control IAM display

### DIFF
--- a/AppboyKit.js
+++ b/AppboyKit.js
@@ -226,7 +226,7 @@
                             if (!(appboy.initialize(forwarderSettings.apiKey))) {
                                 return 'Failed to initialize: ' + name;
                             }
-                            appboy.display.automaticallyShowNewInAppMessages();
+                           
                             appboy.openSession();
                             appboy.requestInAppMessageRefresh();
 
@@ -250,11 +250,13 @@
                     if (!(appboy.initialize(forwarderSettings.apiKey))) {
                         return 'Failed to initialize: ' + name;
                     }
-                    appboy.display.automaticallyShowNewInAppMessages();
+                    
                     appboy.openSession();
                     appboy.requestInAppMessageRefresh();
-
                     isInitialized = true;
+                }
+                if (forwarderSettings.register_inapp == "True") {
+                        appboy.display.automaticallyShowNewInAppMessages();
                 }
                 return 'Successfully initialized: ' + name;
             }

--- a/test/tests.js
+++ b/test/tests.js
@@ -255,6 +255,24 @@ describe('Appboy Forwarder', function () {
         window.appboy.should.have.property('initializeCalled', true);
         window.appboy.should.have.property('openSessionCalled', true);
         window.appboy.should.have.property('inAppMessageRefreshCalled', true);
+        window.appboy.display.should.have.property('automaticallyShowNewInAppMessagesCalled', false);
+    });
+
+    it ('should automatically show in app messages', function(){
+        reportService.reset();
+        window.appboy = new MockAppboy();
+
+        mParticle.forwarder.init({
+            apiKey: '123456',
+            register_inapp: 'True'
+        }, reportService.cb, true, null, {
+            gender: 'm'
+        }, [{
+            Identity: 'testUser',
+            Type: IdentityType.CustomerId
+        }], '1.1', 'My App');
+
+        window.appboy.display.should.have.property('automaticallyShowNewInAppMessagesCalled', true);
     });
 
     it('should log event', function() {


### PR DESCRIPTION
This adds a setting, configurable server-side, allowing customers to
control whether or not Appboy's `automaticallyShowNewInAppMessages`
API is called on initialization. The setting is true by default.